### PR TITLE
feat: 지수 정보 삭제 및 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sprint/findex/config/QueryDSLConfig.java
+++ b/src/main/java/com/sprint/findex/config/QueryDSLConfig.java
@@ -1,0 +1,20 @@
+package com.sprint.findex.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/sprint/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/sprint/findex/controller/IndexInfoController.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +64,21 @@ public class IndexInfoController {
       @Valid @RequestBody IndexInfoUpdateRequest request,
       @PathVariable UUID id) {
     return ResponseEntity.ok(indexInfoService.updateIndexInfoByUser(id, request));
+  }
+
+  @Operation(summary = "지수 정보 삭제", description = "지수 정보를 삭제합니다.관련된 지수 데이터도 함께 삭제됩니다.", operationId = "deleteIndexInfo")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "지수 정보 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "삭제할 지수 정보를 찾을 수 없음",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @Parameter(name = "id", description = "지수 정보 ID")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<IndexInfoDto> deleteIndexInfo(
+      @PathVariable UUID id) {
+    indexInfoService.deleteIndexInfo(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sprint/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/sprint/findex/controller/IndexInfoController.java
@@ -1,28 +1,41 @@
 package com.sprint.findex.controller;
 
+import com.sprint.findex.dto.indexinfo.CursorPageResponseIndexInfoDto;
 import com.sprint.findex.dto.indexinfo.IndexInfoCreateRequest;
 import com.sprint.findex.dto.indexinfo.IndexInfoDto;
+import com.sprint.findex.dto.indexinfo.IndexInfoQueryCondition;
 import com.sprint.findex.dto.indexinfo.IndexInfoUpdateRequest;
+import com.sprint.findex.entity.IndexInfo;
 import com.sprint.findex.exception.ErrorResponse;
 import com.sprint.findex.service.IndexInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -80,5 +93,20 @@ public class IndexInfoController {
       @PathVariable UUID id) {
     indexInfoService.deleteIndexInfo(id);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "지수 정보 목록 조회", description = "지수 정보 목록을 조회합니다. 필터링, 정렬, 커서 기반 페이지네이션을 지원합니다.", operationId = "getIndexInfoList")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "지수 정보 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @GetMapping
+  public ResponseEntity<CursorPageResponseIndexInfoDto> getIndexInfoList(
+      @ParameterObject @ModelAttribute
+      @Valid IndexInfoQueryCondition condition) {
+    return ResponseEntity.ok(indexInfoService.getIndexInfoList(condition));
   }
 }

--- a/src/main/java/com/sprint/findex/dto/indexinfo/CursorPageResponseIndexInfoDto.java
+++ b/src/main/java/com/sprint/findex/dto/indexinfo/CursorPageResponseIndexInfoDto.java
@@ -1,0 +1,28 @@
+package com.sprint.findex.dto.indexinfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "커서 기반 페이지 응답")
+public record CursorPageResponseIndexInfoDto(
+    @Schema(description = "페이지 내용")
+    List<IndexInfoDto> content,
+
+    @Schema(description = "다음 페이지 커서", example = "KOSPI시리즈")
+    String nextCursor,
+
+    @Schema(description = "마지막 요소의 ID", example = "31f6a8b9-cc2c-4c20-b43a-1c96881fafd5")
+    UUID nextIdAfter,
+
+    @Schema(description = "페이지 크기", example = "10")
+    Integer size,
+
+    @Schema(description = "총 요소 수", example = "100")
+    Long totalElements,
+
+    @Schema(description = "다음 페이지 여부", example = "true")
+    Boolean hasNext
+) {
+
+}

--- a/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoDto.java
+++ b/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoDto.java
@@ -1,5 +1,6 @@
 package com.sprint.findex.dto.indexinfo;
 
+import com.sprint.findex.enums.SourceType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoDto.java
+++ b/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoDto.java
@@ -26,7 +26,7 @@ public record IndexInfoDto(
         BigDecimal baseIndex,
 
         @Schema(description = "출처 (사용자/OPEN API)", example = "OPEN_API")
-        String sourceType,
+        SourceType sourceType,
 
         @Schema(description = "즐겨찾기 여부", example = "true")
         Boolean favorite

--- a/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoQueryCondition.java
+++ b/src/main/java/com/sprint/findex/dto/indexinfo/IndexInfoQueryCondition.java
@@ -1,0 +1,55 @@
+package com.sprint.findex.dto.indexinfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.util.UUID;
+
+@Schema(description = "커서 기반 지수 정보 목록 조회 파라미터 목록")
+public record IndexInfoQueryCondition(
+
+    @Schema(description = "지수 분류명")
+    String indexClassification,
+
+    @Schema(description = "지수명")
+    String indexName,
+
+    @Schema(description = "즐겨찾기 여부")
+    Boolean favorite,
+
+    @Schema(description = "이전 페이지 마지막 요소 ID")
+    UUID idAfter,
+
+    @Schema(description = "커서 (다음 페이지 시작점)")
+    String cursor,
+
+    @Schema(description = "정렬 필드( indexClassification, indexName, employedItemsCount)",
+        defaultValue = "indexClassification")
+    @Pattern(regexp = "indexClassification|indexName|employedItemsCount")
+    String sortField,
+
+    @Schema(description = "정렬 방향 (asc, desc)", defaultValue = "asc")
+    @Pattern(regexp = "(?i)(asc|desc)")
+    String sortDirection,
+
+    @Schema(description = "페이지 크기", defaultValue = "10")
+    @Min(1)
+    @Max(100)
+    Integer size
+) {
+
+  public IndexInfoQueryCondition {
+    if (size == null) {
+      size = 10;
+    }
+    if (sortField == null || sortField.isBlank()) {
+      sortField = "indexClassification";
+    }
+    if (sortDirection == null || sortDirection.isBlank()) {
+      sortDirection = "asc";
+    }else {
+      sortDirection = sortDirection.toLowerCase();
+    }
+  }
+}

--- a/src/main/java/com/sprint/findex/exception/ExceptionCode.java
+++ b/src/main/java/com/sprint/findex/exception/ExceptionCode.java
@@ -12,7 +12,7 @@ public enum ExceptionCode {
     INDEX_INFO_ALREADY_EXISTS(409, "INDEX02",
             "Index Already Exists With Same Classification And Name"),
 
-
+    INDEX_INFO_INVALID_QUERY_CONDITION(404, "INDEX03", "Invalid Query Condition"),
     //자동연동설정
     AUTO_SYNC_CONFIG_NOT_FOUND(404, "AUTO_SYNC_CONFIG01", "Auto Sync Config Not Found"),
 

--- a/src/main/java/com/sprint/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexDataRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface IndexDataRepository extends JpaRepository<IndexData, UUID> {
@@ -14,4 +16,8 @@ public interface IndexDataRepository extends JpaRepository<IndexData, UUID> {
 
     List<IndexData> findAllByIndexInfoIdAndCreatedAtBetween(UUID indexInfoId, LocalDate startDate,
             LocalDate endDate, Sort sort);
+
+    @Modifying
+    @Query("delete from IndexData d where d.indexInfo.id = :indexInfoId")
+    void deleteAllByIndexInfoId(UUID indexInfoId);
 }

--- a/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
@@ -1,14 +1,12 @@
 package com.sprint.findex.repository;
 
 import com.sprint.findex.entity.IndexInfo;
-import java.util.Optional;
+import com.sprint.findex.repository.dsl.IndexInfoCustomRepository;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID> {
+public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID>,
+    IndexInfoCustomRepository {
 
-  boolean existsByIndexClassificationAndIndexName(String indexClassification, String IndexName);
-
-  Optional<IndexInfo> findByIndexClassificationAndIndexName(String indexClassification,
-      String indexName);
+    boolean existsByIndexClassificationAndIndexName(String indexClassification, String IndexName);
 }

--- a/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
@@ -2,6 +2,7 @@ package com.sprint.findex.repository;
 
 import com.sprint.findex.entity.IndexInfo;
 import com.sprint.findex.repository.dsl.IndexInfoCustomRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,7 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID>,
     IndexInfoCustomRepository {
 
     boolean existsByIndexClassificationAndIndexName(String indexClassification, String IndexName);
+
+    Optional<IndexInfo> findByIndexClassificationAndIndexName(String indexClassification,
+        String indexName);
 }

--- a/src/main/java/com/sprint/findex/repository/dsl/IndexInfoCustomRepository.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/IndexInfoCustomRepository.java
@@ -1,0 +1,9 @@
+package com.sprint.findex.repository.dsl;
+
+import com.sprint.findex.dto.indexinfo.CursorPageResponseIndexInfoDto;
+import com.sprint.findex.dto.indexinfo.IndexInfoQueryCondition;
+
+public interface IndexInfoCustomRepository {
+
+  CursorPageResponseIndexInfoDto findAllWithIndexInfoQueryCondition(IndexInfoQueryCondition condition);
+}

--- a/src/main/java/com/sprint/findex/repository/dsl/impl/IndexInfoCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/impl/IndexInfoCustomRepositoryImpl.java
@@ -1,0 +1,220 @@
+package com.sprint.findex.repository.dsl.impl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.findex.dto.indexinfo.CursorPageResponseIndexInfoDto;
+import com.sprint.findex.dto.indexinfo.IndexInfoDto;
+import com.sprint.findex.dto.indexinfo.IndexInfoQueryCondition;
+import com.sprint.findex.entity.QIndexInfo;
+import com.sprint.findex.exception.BusinessLogicException;
+import com.sprint.findex.exception.ExceptionCode;
+import com.sprint.findex.mapper.IndexInfoMapper;
+import com.sprint.findex.repository.dsl.IndexInfoCustomRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class IndexInfoCustomRepositoryImpl implements IndexInfoCustomRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  private final IndexInfoMapper indexInfoMapper;
+  private static final QIndexInfo indexInfo = QIndexInfo.indexInfo;
+
+  @Override
+  public CursorPageResponseIndexInfoDto findAllWithIndexInfoQueryCondition(
+      IndexInfoQueryCondition condition) {
+
+    List<IndexInfoDto> content = jpaQueryFactory
+        .select(Projections.constructor(
+            IndexInfoDto.class,
+            indexInfo.id,
+            indexInfo.indexClassification,
+            indexInfo.indexName,
+            indexInfo.employedItemsCount,
+            indexInfo.basePointInTime,
+            indexInfo.baseIndex,
+            indexInfo.sourceType,
+            indexInfo.favorite
+        ))
+        .from(indexInfo)
+        .where(
+            classificationContains(condition.indexClassification()),
+            nameContains(condition.indexName()),
+            favoriteEq(condition.favorite()),
+            cursorCondition(condition)
+        )
+        .orderBy(
+            getOrderSpecifier(condition.sortField(), condition.sortDirection()),
+            getOrderSpecifier("id", condition.sortDirection()))
+        .limit(condition.size()+1)
+        .fetch();
+
+    boolean hasNext = content.size() > condition.size();
+    String nextCursor = null;
+    UUID nextIdAfter = null;
+
+    if (hasNext) {
+      nextIdAfter = content.get(condition.size()-1).id();
+      nextCursor = getNextCursor(content.get(condition.size()-1), condition.sortField());
+      content = content.subList(0, condition.size());
+    }
+
+    long totalElements = (condition.cursor() == null && !hasNext) ? //첫 페이지가 전부인 경우, 추가 쿼리 X
+        content.size() : getTotalElements(condition);
+
+    return new CursorPageResponseIndexInfoDto(content,nextCursor,nextIdAfter, content.size(), totalElements, hasNext);
+  }
+
+  private OrderSpecifier<?> getOrderSpecifier(String sortField, String sortDirection) {
+    Order order = sortDirection.equals("desc") ? Order.DESC : Order.ASC;
+    return new OrderSpecifier<>(order,getSortField(sortField));
+  }
+
+  private ComparableExpressionBase<?> getSortField(String sortField) {
+    return switch (sortField) {
+      case "id" -> indexInfo.id;
+      case "indexName" -> indexInfo.indexName;
+      case "employedItemsCount" -> indexInfo.employedItemsCount;
+      case "favorite" -> indexInfo.favorite;
+      case "basePointInTime" -> indexInfo.basePointInTime;
+      case "baseIndex" -> indexInfo.baseIndex;
+      case "indexClassification" -> indexInfo.indexClassification;
+      default -> throw new BusinessLogicException(ExceptionCode.INDEX_INFO_INVALID_QUERY_CONDITION);//임시
+    };
+  }
+
+  private String getNextCursor(IndexInfoDto lastDto, String sortField) {
+    if(lastDto == null) {
+      return null;
+    }
+    return switch (sortField) {
+      case "id" -> lastDto.id().toString();
+      case "indexName" -> lastDto.indexName();
+      case "indexClassification" -> lastDto.indexClassification();
+      case "favorite" -> lastDto.favorite().toString();
+      case "basePointInTime" -> lastDto.basePointInTime().toString();
+      case "baseIndex" -> lastDto.baseIndex().toString();
+      case "employedItemsCount" -> lastDto.employedItemsCount().toString();
+      default -> throw new BusinessLogicException(ExceptionCode.INDEX_INFO_INVALID_QUERY_CONDITION);
+    };
+  }
+
+  private BooleanExpression classificationContains(String classification){
+    return (classification != null && !classification.isBlank()) ?
+        indexInfo.indexClassification.containsIgnoreCase(classification) : null;
+  }
+
+  private BooleanExpression nameContains(String name) {
+    return (name != null && !name.isBlank()) ?
+        indexInfo.indexName.containsIgnoreCase(name) : null;
+  }
+
+  private BooleanExpression favoriteEq(Boolean favorite) {
+    return favorite != null ? indexInfo.favorite.eq(favorite) : null;
+  }
+
+  private BooleanExpression cursorCondition(IndexInfoQueryCondition condition) {
+    if(condition.cursor() == null|| condition.idAfter()==null) {
+      return null;
+    }
+
+    boolean asc = !condition.sortDirection().equals("desc");
+
+    try{
+      switch (condition.sortField()) {
+        case "id":
+          if(asc) {
+            return indexInfo.id.gt(UUID.fromString(condition.cursor()));
+          }else {
+            return indexInfo.id.lt(UUID.fromString(condition.cursor()));
+          }
+        case "indexName":
+          if(asc) {
+            return indexInfo.indexName.gt(condition.cursor())
+                .or(indexInfo.indexName.eq(condition.cursor())
+                    .and(indexInfo.id.gt(condition.idAfter())));
+          }else{
+            return indexInfo.indexName.lt(condition.cursor())
+                .or(indexInfo.indexName.eq(condition.cursor())
+                    .and(indexInfo.id.lt(condition.idAfter())));
+          }
+        case "indexClassification":
+          if(asc) {
+            return indexInfo.indexClassification.gt(condition.cursor())
+                .or(indexInfo.indexClassification.eq(condition.cursor())
+                    .and(indexInfo.id.gt(condition.idAfter())));
+          }else {
+            return indexInfo.indexClassification.lt(condition.cursor())
+                .or(indexInfo.indexClassification.eq(condition.cursor())
+                    .and(indexInfo.id.lt(condition.idAfter())));
+          }
+        case "employedItemsCount":
+          if(asc) {
+            return indexInfo.employedItemsCount.gt(Integer.valueOf(condition.cursor()))
+                .or(indexInfo.employedItemsCount.eq(Integer.valueOf(condition.cursor()))
+                    .and(indexInfo.id.gt(condition.idAfter())));
+          }else{
+            return indexInfo.employedItemsCount.lt(Integer.valueOf(condition.cursor()))
+                .or(indexInfo.employedItemsCount.eq(Integer.valueOf(condition.cursor()))
+                    .and(indexInfo.id.lt(condition.idAfter())));
+          }
+        case "favorite":
+          if(asc) {
+            return indexInfo.favorite.eq(Boolean.valueOf(condition.cursor()))
+                .and(indexInfo.id.gt(condition.idAfter()));
+          }else {
+            return indexInfo.favorite.eq(Boolean.valueOf(condition.cursor()))
+                .and(indexInfo.id.lt(condition.idAfter()));
+          }
+        case "basePointInTime":
+          if(asc) {
+            return indexInfo.basePointInTime.gt(LocalDate.parse(condition.cursor()))
+                .or(indexInfo.basePointInTime.eq(LocalDate.parse(condition.cursor()))
+                    .and(indexInfo.id.gt(condition.idAfter())));
+          }else {
+            return indexInfo.basePointInTime.lt(LocalDate.parse(condition.cursor()))
+                .or(indexInfo.basePointInTime.eq(LocalDate.parse(condition.cursor()))
+                    .and(indexInfo.id.lt(condition.idAfter())));
+          }
+        case "baseIndex":
+          BigDecimal cursorValue = new BigDecimal(condition.cursor());
+          if(asc) {
+            return indexInfo.baseIndex.gt(cursorValue)
+                .or((indexInfo.baseIndex.eq(cursorValue))
+                    .and(indexInfo.id.gt(condition.idAfter())));
+          }else {
+            return indexInfo.baseIndex.lt(cursorValue)
+                .or((indexInfo.baseIndex.eq(cursorValue))
+                    .and(indexInfo.id.lt(condition.idAfter())));
+          }
+        default:
+          throw new BusinessLogicException(ExceptionCode.INDEX_INFO_INVALID_QUERY_CONDITION);//임시
+      }
+    }catch (NumberFormatException | DateTimeParseException e) {
+      throw new BusinessLogicException(ExceptionCode.INDEX_INFO_INVALID_QUERY_CONDITION);
+    }
+
+
+  }
+
+  private Long getTotalElements(IndexInfoQueryCondition condition) {
+    return jpaQueryFactory
+        .select(indexInfo.count())
+        .from(indexInfo)
+        .where(
+            classificationContains(condition.indexClassification()),
+            nameContains(condition.indexName()),
+            favoriteEq(condition.favorite())
+        ).fetchOne();
+  }
+}

--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -10,6 +10,7 @@ import com.sprint.findex.enums.SourceType;
 import com.sprint.findex.exception.BusinessLogicException;
 import com.sprint.findex.exception.ExceptionCode;
 import com.sprint.findex.mapper.IndexInfoMapper;
+import com.sprint.findex.repository.IndexDataRepository;
 import com.sprint.findex.repository.IndexInfoRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class IndexInfoService {
   private final IndexInfoRepository indexInfoRepository;
   private final IndexInfoMapper indexInfoMapper;
   private final AutoSyncConfigService autoSyncConfigService;
+  private final IndexDataRepository indexDataRepository;
 
   public IndexInfoDto createIndexInfoByUser(IndexInfoCreateRequest request) {
     validateDuplicateIndexInfo(request);
@@ -56,7 +58,7 @@ public class IndexInfoService {
     if (!indexInfoRepository.existsById(id)) {
       throw new BusinessLogicException(ExceptionCode.INDEX_INFO_NOT_FOUND);
     }
-    //지수데이터 정보 아이디 기반 삭제 - deleteAllByIndexInfoId(관련 레포 또는 서비스 생성 시 추가 예정
+    indexDataRepository.deleteAllByIndexInfoId(id);
     indexInfoRepository.deleteById(id);
   }
 

--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -1,7 +1,9 @@
 package com.sprint.findex.service;
 
+import com.sprint.findex.dto.indexinfo.CursorPageResponseIndexInfoDto;
 import com.sprint.findex.dto.indexinfo.IndexInfoCreateRequest;
 import com.sprint.findex.dto.indexinfo.IndexInfoDto;
+import com.sprint.findex.dto.indexinfo.IndexInfoQueryCondition;
 import com.sprint.findex.dto.indexinfo.IndexInfoUpdateRequest;
 import com.sprint.findex.entity.IndexInfo;
 import com.sprint.findex.enums.SourceType;
@@ -9,7 +11,6 @@ import com.sprint.findex.exception.BusinessLogicException;
 import com.sprint.findex.exception.ExceptionCode;
 import com.sprint.findex.mapper.IndexInfoMapper;
 import com.sprint.findex.repository.IndexInfoRepository;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,11 +53,15 @@ public class IndexInfoService {
   }
 
   public void deleteIndexInfo(UUID id) {
-    if(!indexInfoRepository.existsById(id)) {
+    if (!indexInfoRepository.existsById(id)) {
       throw new BusinessLogicException(ExceptionCode.INDEX_INFO_NOT_FOUND);
     }
     //지수데이터 정보 아이디 기반 삭제 - deleteAllByIndexInfoId(관련 레포 또는 서비스 생성 시 추가 예정
     indexInfoRepository.deleteById(id);
+  }
+
+  public CursorPageResponseIndexInfoDto getIndexInfoList(IndexInfoQueryCondition condition) {
+    return indexInfoRepository.findAllWithIndexInfoQueryCondition(condition);
   }
 
   private void validateDuplicateIndexInfo(IndexInfoCreateRequest request) {

--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -51,6 +51,14 @@ public class IndexInfoService {
     return indexInfoMapper.toDto(indexInfo);
   }
 
+  public void deleteIndexInfo(UUID id) {
+    if(!indexInfoRepository.existsById(id)) {
+      throw new BusinessLogicException(ExceptionCode.INDEX_INFO_NOT_FOUND);
+    }
+    //지수데이터 정보 아이디 기반 삭제 - deleteAllByIndexInfoId(관련 레포 또는 서비스 생성 시 추가 예정
+    indexInfoRepository.deleteById(id);
+  }
+
   private void validateDuplicateIndexInfo(IndexInfoCreateRequest request) {
     if (indexInfoRepository.existsByIndexClassificationAndIndexName(
         request.indexClassification(),


### PR DESCRIPTION
## 관련 이슈
- closes #19 
- closes #20 

## 작업 내용
- 지수 정보 삭제 및 관련 데이터 연관삭제 구현
  - "/api/index-infos/{id}" DELETE 요청(`deleteIndexInfo`)
  - service 계층에 `deleteIndexInfo`메서드를 추가하였습니다.
- 지수 정보 목록 조회 커서 페이지네이션 구현
  - "/api/index-infos" GET 요청(`getIndexInfoList`)
  - 서비스 계층에 `getIndexInfoList` 메서들르 추가하였습니다.

## 변경 사항
- `QueryDSLConfig.java`을 추가했습니다.
- repository/dsl 패키지에 interface repository(`indexInfoCustomRepository`)를 추가했습니다.
- impl 패키지에 repository 구현체(`indexInfoCustomRepositoryImpl`)를 추가했습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 정렬 필드가 변경되기 때문에 정렬필드의 `BooleanExpression`의 추상화가 불가하다고 판단하여 분기문으로 작성하였습니다.
- 정렬 필드 쿼리 요청 DTO 
```
{
            "name": "sortField",
            "in": "query",
            "description": "정렬 필드( indexClassification, indexName, employedItemsCount)",
            "required": false,
            "schema": {
              "type": "string",
              "default": "indexClassification",
              "description": "정렬 필드( indexClassification, indexName, employedItemsCount)",
              "enum": [
                "indexClassification",
                "indexName",
                "employedItemsCount"
              ]
            }
          },
```
