### PR TITLE
feat: 대시보드 날짜 조회 반대로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ out/
 # Gradle
 .gradle/
 build/
-gradle-user-home/
+.gradle-user-home/
 
 # Logs
 *.log

--- a/src/main/java/com/sprint/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/sprint/findex/repository/DashboardRepository.java
@@ -26,7 +26,7 @@ public interface DashboardRepository extends JpaRepository<IndexData, UUID> {
             """)
     List<IndexData> findLatestFavoriteIndexData();
 
-    Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
+    Optional<IndexData> findTopByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(
             UUID indexInfoId,
             LocalDate baseDate
     );

--- a/src/main/java/com/sprint/findex/service/DashboardService.java
+++ b/src/main/java/com/sprint/findex/service/DashboardService.java
@@ -5,10 +5,12 @@ import com.sprint.findex.entity.IndexData;
 import com.sprint.findex.enums.PeriodType;
 import com.sprint.findex.mapper.DashboardMapper;
 import com.sprint.findex.repository.DashboardRepository;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,7 +47,7 @@ public class DashboardService {
 
         LocalDate targetDate = getTargetDate(data.getBaseDate(), periodType);
         return dashboardRepository
-                .findTopByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
+                .findTopByIndexInfoIdAndBaseDateGreaterThanEqualOrderByBaseDateAsc(
                         data.getIndexInfo().getId(),
                         targetDate
                 )


### PR DESCRIPTION
## 관련 이슈
- closes #22

## 작업 내용
- 레포지토리 메서드 수정

## 변경 사항
- targetDate에 데이터가 없으면 더 이전 날짜 데이터를 가져오는 것이 아닌, targetDate와 가까운 날짜를 조회하는 것으로 변경하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
