### PR TITLE
fix: projection 순서 오류 수정

### DIFF
--- a/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
@@ -17,7 +17,7 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID>,
     Optional<IndexInfo> findByIndexClassificationAndIndexName(String indexClassification,
         String indexName);
 
-    @Query("SELECT new com.sprint.findex.dto.indexinfo.IndexInfoSummaryDto(i.id, i.indexName, i.indexClassification ) "
+    @Query("SELECT new com.sprint.findex.dto.indexinfo.IndexInfoSummaryDto(i.id, i.indexClassification,i.indexName ) "
         + "FROM IndexInfo i")
     List<IndexInfoSummaryDto> findAllSummaries();
 }


### PR DESCRIPTION
## 관련 이슈
- closes #62 

## 작업 내용
- 지수 정보 요약 목록 조회 시, 지수 이름과 지수 분류 이름이 바뀌어 조회 되는 문제를 해결했습니다.

## 변경 사항
- `IndexInfoRepository`의 `findAllSummaries`쿼리문에서 indexName과 indexClassification 순서를 변경하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
