### PR TITLE
feat: 자동 연동 설정 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sprint/findex/controller/AutoSyncConfigController.java
+++ b/src/main/java/com/sprint/findex/controller/AutoSyncConfigController.java
@@ -1,7 +1,9 @@
 package com.sprint.findex.controller;
 
 import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigDto;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigQueryCondition;
 import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigUpdateRequest;
+import com.sprint.findex.dto.response.PageResponse;
 import com.sprint.findex.exception.ErrorResponse;
 import com.sprint.findex.service.AutoSyncConfigService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,7 +16,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,5 +54,27 @@ public class AutoSyncConfigController {
         AutoSyncConfigDto autoSyncConfigDto = autoSyncConfigService.updateAutoSyncConfig(id, request);
 
         return ResponseEntity.ok(autoSyncConfigDto);
+    }
+
+    @Operation(
+            summary = "자동 연동 설정 목록 조회",
+            description = "자동 연동 설정 목록을 조회합니다. 지수, 활성화 여부 필터링과 정렬, "
+                    + "커서 기반 페이지네이션을 지원합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "자동 연동 설정 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 필터 값 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping
+    public ResponseEntity<PageResponse<AutoSyncConfigDto>> findAllAutoSyncConfigs(
+            @ParameterObject @Valid @ModelAttribute AutoSyncConfigQueryCondition condition
+    ) {
+        PageResponse<AutoSyncConfigDto> response = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sprint/findex/dto/autosyncconfig/AutoSyncConfigQueryCondition.java
+++ b/src/main/java/com/sprint/findex/dto/autosyncconfig/AutoSyncConfigQueryCondition.java
@@ -1,0 +1,60 @@
+package com.sprint.findex.dto.autosyncconfig;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.util.UUID;
+
+@Schema(description = "커서 기반 자동 연동 설정 목록 조회 파라미터")
+public record AutoSyncConfigQueryCondition(
+        @Schema(description = "지수 정보 ID",
+                example = "123e4567-e89b-12d3-a456-426614174001")
+        UUID indexInfoId,
+
+        @Schema(description = "활성화 여부", example = "true")
+        Boolean enabled,
+
+        @Schema(description = "이전 페이지 마지막 요소 ID",
+                example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID idAfter,
+
+        @Schema(description = "커서 (다음 페이지 시작점)", example = "IT 서비스")
+        String cursor,
+
+        @Schema(description = "정렬 필드 (indexInfo.indexName, enabled)",
+                defaultValue = "indexInfo.indexName")
+        @Pattern(regexp = "indexInfo\\.indexName|enabled")
+        String sortField,
+
+        @Schema(description = "정렬 방향 (asc, desc)", defaultValue = "asc")
+        @Pattern(regexp = "(?i)(asc|desc)")
+        String sortDirection,
+
+        @Schema(description = "페이지 크기", defaultValue = "10")
+        @Min(1)
+        @Max(100)
+        Integer size
+) {
+
+    public AutoSyncConfigQueryCondition {
+        if (size == null) {
+            size = 10;
+        }
+        if (sortField == null || sortField.isBlank()) {
+            sortField = "indexInfo.indexName";
+        }
+        if (sortDirection == null || sortDirection.isBlank()) {
+            sortDirection = "asc";
+        } else {
+            sortDirection = sortDirection.toLowerCase();
+        }
+    }
+
+    @AssertTrue(message = "cursor와 idAfter는 함께 요청되어야 합니다.")
+    @Schema(hidden = true)
+    public boolean isCursorPairValid() {
+        return (cursor == null && idAfter == null) || (cursor != null && idAfter != null);
+    }
+}

--- a/src/main/java/com/sprint/findex/dto/response/PageResponse.java
+++ b/src/main/java/com/sprint/findex/dto/response/PageResponse.java
@@ -1,0 +1,31 @@
+package com.sprint.findex.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "페이지네이션 응답 DTO")
+public record PageResponse<T>(
+        @Schema(description = "실제 데이터")
+        List<T> content,
+
+        @Schema(description = "다음 페이지 커서")
+        String nextCursor,
+
+        @Schema(
+                description = "마지막 요소 ID",
+                example = "123e4567-e89b-12d3-a456-426614174000"
+        )
+        UUID nextIdAfter,
+
+        @Schema(description = "실제 반환된 데이터 수", example = "10")
+        int size,
+
+        @Schema(description = "전체 데이터 수", example = "100")
+        Long totalElements,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+
+}

--- a/src/main/java/com/sprint/findex/exception/ExceptionCode.java
+++ b/src/main/java/com/sprint/findex/exception/ExceptionCode.java
@@ -13,8 +13,10 @@ public enum ExceptionCode {
             "Index Already Exists With Same Classification And Name"),
 
     INDEX_INFO_INVALID_QUERY_CONDITION(404, "INDEX03", "Invalid Query Condition"),
+
     //자동연동설정
     AUTO_SYNC_CONFIG_NOT_FOUND(404, "AUTO_SYNC_CONFIG01", "Auto Sync Config Not Found"),
+    AUTO_SYNC_CONFIG_INVALID_QUERY_CONDITION(400, "AUTO_SYNC_CONFIG02", "Invalid Auto Sync Config Query Condition"),
 
     // 지수 데이터
     INDEX_DATA_NOT_FOUND(404, "INDEX_DATA01", "Index Data Not Found"),

--- a/src/main/java/com/sprint/findex/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/sprint/findex/repository/AutoSyncConfigRepository.java
@@ -1,9 +1,10 @@
 package com.sprint.findex.repository;
 
 import com.sprint.findex.entity.AutoSyncConfig;
+import com.sprint.findex.repository.dsl.AutoSyncConfigCustomRepository;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, UUID> {
-
+public interface AutoSyncConfigRepository
+        extends JpaRepository<AutoSyncConfig, UUID>, AutoSyncConfigCustomRepository {
 }

--- a/src/main/java/com/sprint/findex/repository/dsl/AutoSyncConfigCustomRepository.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/AutoSyncConfigCustomRepository.java
@@ -1,0 +1,10 @@
+package com.sprint.findex.repository.dsl;
+
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigDto;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigQueryCondition;
+import com.sprint.findex.dto.response.PageResponse;
+
+public interface AutoSyncConfigCustomRepository {
+
+    PageResponse<AutoSyncConfigDto> findAllWithCondition(AutoSyncConfigQueryCondition condition);
+}

--- a/src/main/java/com/sprint/findex/repository/dsl/impl/AutoSyncConfigCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/impl/AutoSyncConfigCustomRepositoryImpl.java
@@ -1,0 +1,167 @@
+package com.sprint.findex.repository.dsl.impl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigDto;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigQueryCondition;
+import com.sprint.findex.dto.response.PageResponse;
+import com.sprint.findex.entity.QAutoSyncConfig;
+import com.sprint.findex.exception.BusinessLogicException;
+import com.sprint.findex.exception.ExceptionCode;
+import com.sprint.findex.repository.dsl.AutoSyncConfigCustomRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AutoSyncConfigCustomRepositoryImpl implements AutoSyncConfigCustomRepository {
+
+    private static final QAutoSyncConfig autoSyncConfig = QAutoSyncConfig.autoSyncConfig;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public PageResponse<AutoSyncConfigDto> findAllWithCondition(
+            AutoSyncConfigQueryCondition condition
+    ) {
+        List<AutoSyncConfigDto> content = jpaQueryFactory
+                .select(Projections.constructor(
+                        AutoSyncConfigDto.class,
+                        autoSyncConfig.id,
+                        autoSyncConfig.indexInfo.id,
+                        autoSyncConfig.indexInfo.indexClassification,
+                        autoSyncConfig.indexInfo.indexName,
+                        autoSyncConfig.enabled
+                ))
+                .from(autoSyncConfig)
+                .where(
+                        indexInfoIdEq(condition.indexInfoId()),
+                        enabledEq(condition.enabled()),
+                        cursorCondition(condition)
+                )
+                .orderBy(
+                        getOrderSpecifier(condition.sortField(), condition.sortDirection()),
+                        getOrderSpecifier("id", condition.sortDirection())
+                )
+                .limit(condition.size() + 1L)
+                .fetch();
+
+        boolean hasNext = content.size() > condition.size();
+        String nextCursor = null;
+        UUID nextIdAfter = null;
+
+        if (hasNext) {
+            AutoSyncConfigDto lastItem = content.get(condition.size() - 1);
+            nextCursor = getNextCursor(lastItem, condition.sortField());
+            nextIdAfter = lastItem.id();
+            content = content.subList(0, condition.size());
+        }
+
+        long totalElements = (condition.cursor() == null && !hasNext)
+                ? content.size()
+                : getTotalElements(condition);
+
+        return new PageResponse<>(
+                content,
+                nextCursor,
+                nextIdAfter,
+                content.size(),
+                totalElements,
+                hasNext
+        );
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortField, String sortDirection) {
+        Order order = "desc".equalsIgnoreCase(sortDirection) ? Order.DESC : Order.ASC;
+        return new OrderSpecifier<>(order, getSortField(sortField));
+    }
+
+    private ComparableExpressionBase<?> getSortField(String sortField) {
+        return switch (sortField) {
+            case "id" -> autoSyncConfig.id;
+            case "enabled" -> autoSyncConfig.enabled;
+            case "indexInfo.indexName" -> autoSyncConfig.indexInfo.indexName;
+            default -> throw new BusinessLogicException(
+                    ExceptionCode.AUTO_SYNC_CONFIG_INVALID_QUERY_CONDITION);
+        };
+    }
+
+    private BooleanExpression indexInfoIdEq(UUID indexInfoId) {
+        return indexInfoId != null ? autoSyncConfig.indexInfo.id.eq(indexInfoId) : null;
+    }
+
+    private BooleanExpression enabledEq(Boolean enabled) {
+        return enabled != null ? autoSyncConfig.enabled.eq(enabled) : null;
+    }
+
+    private String getNextCursor(AutoSyncConfigDto lastDto, String sortField) {
+        return switch (sortField) {
+            case "enabled" -> String.valueOf(lastDto.enabled());
+            case "indexInfo.indexName" -> lastDto.indexName();
+            default -> throw new BusinessLogicException(
+                    ExceptionCode.AUTO_SYNC_CONFIG_INVALID_QUERY_CONDITION);
+        };
+    }
+
+    private BooleanExpression cursorCondition(AutoSyncConfigQueryCondition condition) {
+        if (condition.cursor() == null || condition.idAfter() == null) {
+            return null;
+        }
+
+        boolean asc = !"desc".equalsIgnoreCase(condition.sortDirection());
+
+        switch (condition.sortField()) {
+            case "indexInfo.indexName":
+                if (asc) {
+                    return autoSyncConfig.indexInfo.indexName.gt(condition.cursor())
+                            .or(autoSyncConfig.indexInfo.indexName.eq(condition.cursor())
+                                    .and(autoSyncConfig.id.gt(condition.idAfter())));
+                }
+                return autoSyncConfig.indexInfo.indexName.lt(condition.cursor())
+                        .or(autoSyncConfig.indexInfo.indexName.eq(condition.cursor())
+                                .and(autoSyncConfig.id.lt(condition.idAfter())));
+
+            case "enabled":
+                boolean cursorValue = Boolean.parseBoolean(condition.cursor());
+
+                if (asc) {
+                    if (!cursorValue) {
+                        return autoSyncConfig.enabled.isTrue()
+                                .or(autoSyncConfig.enabled.eq(false)
+                                        .and(autoSyncConfig.id.gt(condition.idAfter())));
+                    }
+                    return autoSyncConfig.enabled.eq(true)
+                            .and(autoSyncConfig.id.gt(condition.idAfter()));
+                }
+
+                if (cursorValue) {
+                    return autoSyncConfig.enabled.isFalse()
+                            .or(autoSyncConfig.enabled.eq(true)
+                                    .and(autoSyncConfig.id.lt(condition.idAfter())));
+                }
+                return autoSyncConfig.enabled.eq(false)
+                        .and(autoSyncConfig.id.lt(condition.idAfter()));
+
+            default:
+                throw new BusinessLogicException(
+                        ExceptionCode.AUTO_SYNC_CONFIG_INVALID_QUERY_CONDITION);
+        }
+    }
+
+    private Long getTotalElements(AutoSyncConfigQueryCondition condition) {
+        return jpaQueryFactory
+                .select(autoSyncConfig.count())
+                .from(autoSyncConfig)
+                .where(
+                        indexInfoIdEq(condition.indexInfoId()),
+                        enabledEq(condition.enabled())
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/sprint/findex/service/AutoSyncConfigService.java
+++ b/src/main/java/com/sprint/findex/service/AutoSyncConfigService.java
@@ -1,7 +1,9 @@
 package com.sprint.findex.service;
 
 import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigDto;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigQueryCondition;
 import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigUpdateRequest;
+import com.sprint.findex.dto.response.PageResponse;
 import com.sprint.findex.entity.AutoSyncConfig;
 import com.sprint.findex.entity.IndexInfo;
 import com.sprint.findex.exception.BusinessLogicException;
@@ -30,6 +32,13 @@ public class AutoSyncConfigService {
         return autoSyncConfigMapper.toDto(saved);
     }
 
+    @Transactional(readOnly = true)
+    public PageResponse<AutoSyncConfigDto> findAllAutoSyncConfigs(
+        AutoSyncConfigQueryCondition condition
+    ) {
+        return autoSyncConfigRepository.findAllWithCondition(condition);
+    }
+
     @Transactional
     public AutoSyncConfigDto updateAutoSyncConfig(
             UUID autoSyncConfigId,
@@ -43,7 +52,6 @@ public class AutoSyncConfigService {
 
     private AutoSyncConfig getAutoSyncConfigOrThrow(UUID autoSyncConfigId) {
         return autoSyncConfigRepository.findById(autoSyncConfigId)
-                .orElseThrow(
-                        () -> new BusinessLogicException(ExceptionCode.AUTO_SYNC_CONFIG_NOT_FOUND));
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.AUTO_SYNC_CONFIG_NOT_FOUND));
     }
 }

--- a/src/test/java/com/sprint/findex/service/AutoSyncConfigServiceTest.java
+++ b/src/test/java/com/sprint/findex/service/AutoSyncConfigServiceTest.java
@@ -1,0 +1,229 @@
+package com.sprint.findex.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigDto;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigQueryCondition;
+import com.sprint.findex.dto.autosyncconfig.AutoSyncConfigUpdateRequest;
+import com.sprint.findex.dto.response.PageResponse;
+import com.sprint.findex.entity.IndexInfo;
+import com.sprint.findex.enums.SourceType;
+import com.sprint.findex.exception.BusinessLogicException;
+import com.sprint.findex.exception.ExceptionCode;
+import com.sprint.findex.repository.AutoSyncConfigRepository;
+import com.sprint.findex.repository.IndexInfoRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class AutoSyncConfigServiceTest {
+
+    @Autowired
+    private AutoSyncConfigService autoSyncConfigService;
+
+    @Autowired
+    private IndexInfoRepository indexInfoRepository;
+
+    @Autowired
+    private AutoSyncConfigRepository autoSyncConfigRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("자동 연동 설정 생성 성공")
+    void createAutoSyncConfig_success() {
+        IndexInfo savedIndexInfo = indexInfoRepository.save(createIndexInfo());
+
+        AutoSyncConfigDto result = autoSyncConfigService.createAutoSyncConfig(savedIndexInfo);
+
+        assertThat(result.id()).isNotNull();
+        assertThat(result.indexInfoId()).isEqualTo(savedIndexInfo.getId());
+        assertThat(result.indexClassification()).isEqualTo(savedIndexInfo.getIndexClassification());
+        assertThat(result.indexName()).isEqualTo(savedIndexInfo.getIndexName());
+        assertThat(result.enabled()).isFalse();
+        assertThat(autoSyncConfigRepository.findById(result.id())).isPresent();
+    }
+
+    @Test
+    @DisplayName("자동 연동 설정 수정 성공")
+    void updateAutoSyncConfig_success() {
+        IndexInfo savedIndexInfo = indexInfoRepository.save(createIndexInfo());
+        AutoSyncConfigDto created = autoSyncConfigService.createAutoSyncConfig(savedIndexInfo);
+        AutoSyncConfigUpdateRequest request = new AutoSyncConfigUpdateRequest(true);
+
+        AutoSyncConfigDto result = autoSyncConfigService.updateAutoSyncConfig(created.id(), request);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.id()).isEqualTo(created.id());
+        assertThat(result.indexInfoId()).isEqualTo(savedIndexInfo.getId());
+        assertThat(result.enabled()).isTrue();
+
+        assertThat(autoSyncConfigRepository.findById(created.id()))
+                .get()
+                .extracting(autoSyncConfig -> autoSyncConfig.isEnabled())
+                .isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("자동 연동 설정 수정 실패 - 존재하지 않는 설정")
+    void updateAutoSyncConfig_notFound() {
+        AutoSyncConfigUpdateRequest request = new AutoSyncConfigUpdateRequest(true);
+
+        assertThatThrownBy(() -> autoSyncConfigService.updateAutoSyncConfig(UUID.randomUUID(), request))
+                .isInstanceOf(BusinessLogicException.class)
+                .extracting(exception -> ((BusinessLogicException) exception).getExceptionCode())
+                .isEqualTo(ExceptionCode.AUTO_SYNC_CONFIG_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - 기본 조건")
+    void findAllAutoSyncConfigs_defaultCondition_success() {
+        createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+        createAutoSyncConfigWith("다 서비스");
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(null, null, null, null, null, null, null);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        assertThat(result.content()).hasSize(3);
+        assertThat(result.totalElements()).isEqualTo(3L);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - enabled 필터")
+    void findAllAutoSyncConfigs_filterByEnabled_success() {
+        AutoSyncConfigDto config1 = createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+
+        autoSyncConfigService.updateAutoSyncConfig(config1.id(), new AutoSyncConfigUpdateRequest(true));
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(null, true, null, null, null, null, null);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        assertThat(result.content()).allMatch(AutoSyncConfigDto::enabled);
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - indexInfoId 필터")
+    void findAllAutoSyncConfigs_filterByIndexInfoId_success() {
+        AutoSyncConfigDto target = createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(target.indexInfoId(), null, null, null, null, null, null);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().get(0).indexInfoId()).isEqualTo(target.indexInfoId());
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - indexName 오름차순")
+    void findAllAutoSyncConfigs_sortByIndexName_asc_success() {
+        createAutoSyncConfigWith("다 서비스");
+        createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(null, null, null, null, "indexInfo.indexName", "asc", null);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        List<String> names = result.content().stream().map(AutoSyncConfigDto::indexName).toList();
+        assertThat(names).isSorted();
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - 다음 페이지 존재")
+    void findAllAutoSyncConfigs_hasNext_success() {
+        createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+        createAutoSyncConfigWith("다 서비스");
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(null, null, null, null, null, null, 2);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.nextCursor()).isNotNull();
+        assertThat(result.nextIdAfter()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - enabled 필터 + indexName 정렬")
+    void findAllAutoSyncConfigs_filterByEnabledAndSortByIndexName_success() {
+        AutoSyncConfigDto naService = createAutoSyncConfigWith("나 서비스");
+        AutoSyncConfigDto gaService = createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("라 서비스");
+        AutoSyncConfigDto daService = createAutoSyncConfigWith("다 서비스");
+
+        autoSyncConfigService.updateAutoSyncConfig(gaService.id(), new AutoSyncConfigUpdateRequest(true));
+        autoSyncConfigService.updateAutoSyncConfig(daService.id(), new AutoSyncConfigUpdateRequest(true));
+
+        AutoSyncConfigQueryCondition condition = new AutoSyncConfigQueryCondition(null, true, null, null, "indexInfo.indexName", "asc", null);
+        PageResponse<AutoSyncConfigDto> result = autoSyncConfigService.findAllAutoSyncConfigs(condition);
+
+        assertThat(result.content()).hasSize(2);
+        assertThat(result.content()).allMatch(AutoSyncConfigDto::enabled);
+        List<String> names = result.content().stream().map(AutoSyncConfigDto::indexName).toList();
+        assertThat(names).isSorted();
+        assertThat(names).containsExactly("가 서비스", "다 서비스");
+    }
+
+    @Test
+    @DisplayName("목록 조회 성공 - 커서 페이지네이션")
+    void findAllAutoSyncConfigs_cursorPagination_success() {
+        createAutoSyncConfigWith("가 서비스");
+        createAutoSyncConfigWith("나 서비스");
+        createAutoSyncConfigWith("다 서비스");
+
+        AutoSyncConfigQueryCondition firstPage = new AutoSyncConfigQueryCondition(null, null, null, null, "indexInfo.indexName", "asc", 2);
+        PageResponse<AutoSyncConfigDto> first = autoSyncConfigService.findAllAutoSyncConfigs(firstPage);
+
+        assertThat(first.hasNext()).isTrue();
+
+        AutoSyncConfigQueryCondition secondPage = new AutoSyncConfigQueryCondition(null, null, first.nextIdAfter(), first.nextCursor(), "indexInfo.indexName", "asc", 2);
+        PageResponse<AutoSyncConfigDto> second = autoSyncConfigService.findAllAutoSyncConfigs(secondPage);
+
+        assertThat(second.content()).hasSize(1);
+        assertThat(second.content().get(0).indexName()).isEqualTo("다 서비스");
+    }
+
+    private AutoSyncConfigDto createAutoSyncConfigWith(String indexName) {
+        IndexInfo indexInfo = IndexInfo.create(
+                indexName,
+                "KOSPI시리즈",
+                42,
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("1000.1234"),
+                SourceType.USER,
+                false
+        );
+        IndexInfo savedIndexInfo = indexInfoRepository.save(indexInfo);
+        return autoSyncConfigService.createAutoSyncConfig(savedIndexInfo);
+    }
+
+    private IndexInfo createIndexInfo() {
+        return IndexInfo.create(
+                "IT 서비스",
+                "KOSPI시리즈",
+                42,
+                LocalDate.of(2024, 1, 2),
+                new BigDecimal("1000.1234"),
+                SourceType.USER,
+                false
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #28 

## 작업 내용
- 자동 연동 설정 목록 조회 API에 필터링, 단일 정렬, 커서 페이지네이션 구조를 추가했습니다.
- PageResponse<T> 공통 응답을 위해 페이지 DTO 를 추가했습니다.
- 요청 DTO와 컨트롤러에 Swagger 문서 및 validation을 추가했습니다.

## 변경 사항
- `AutoSyncConfigQueryCondition` 추가
  - `indexInfoId`, `enabled` 필터
  - `sortField`, `sortDirection`, `cursor`, `idAfter`, `size` 지원
  - 기본값 및 validation 추가
- `AutoSyncConfigController` 목록 조회 API Swagger 문서 추가
- `AutoSyncConfigCustomRepository` / `Impl` 추가
  - QueryDSL 기반 목록 조회
  - `indexInfo.indexName`, `enabled` 조건 필터
- `AUTO_SYNC_CONFIG_INVALID_QUERY_CONDITION` 예외 코드 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
