### PR TITLE
feat: 자동 연동 기준일 정책 변경 및 테스트 보완

### DIFF
--- a/src/main/java/com/sprint/findex/service/IntegrationTaskService.java
+++ b/src/main/java/com/sprint/findex/service/IntegrationTaskService.java
@@ -16,13 +16,13 @@ public class IntegrationTaskService {
 
     private final IntegrationTaskRepository integrationTaskRepository;
 
-    //연동 이력 성공 데이터 중 indexInfoId 별 최신 날짜를 찾고 없다면 null 반환
     public List<IndexDataSyncRequest> buildAutoSyncTargets(List<UUID> indexInfoIds, LocalDate baseDateTo) {
         return indexInfoIds.stream()
                 .map(id -> {
                     LocalDate baseDateFrom = integrationTaskRepository.findLastIndexDataSyncDate(id)
                             .map(lastDate -> lastDate.plusDays(1))
-                            .orElse(null);
+                            .orElse(baseDateTo);
+
                     return new IndexDataSyncRequest(List.of(id), baseDateFrom, baseDateTo);
                 })
                 .filter(request -> request.baseDateFrom() == null || !request.baseDateFrom().isAfter(baseDateTo))

--- a/src/test/java/com/sprint/findex/service/IntegrationTaskServiceTest.java
+++ b/src/test/java/com/sprint/findex/service/IntegrationTaskServiceTest.java
@@ -53,8 +53,8 @@ class IntegrationTaskServiceTest {
     }
 
     @Test
-    @DisplayName("자동 연동 대상 생성 - 성공 이력이 없으면 baseDateFrom은 null")
-    void buildAutoSyncTargets_withNoHistory_returnsNullBaseDateFrom() {
+    @DisplayName("자동 연동 대상 생성 - 연동 이력이 없으면 baseDateTo 하루만 요청")
+    void buildAutoSyncTargets_withNoHistory_requestsOnlyBaseDateTo() {
         IndexInfo indexInfo = indexInfoRepository.save(createIndexInfo("KOSPI"));
 
         List<IndexDataSyncRequest> targets = integrationTaskService.buildAutoSyncTargets(
@@ -63,12 +63,13 @@ class IntegrationTaskServiceTest {
 
         assertThat(targets).hasSize(1);
         assertThat(targets.get(0).indexInfoIds()).containsExactly(indexInfo.getId());
-        assertThat(targets.get(0).baseDateFrom()).isNull();
+        assertThat(targets.get(0).baseDateFrom()).isEqualTo(BASE_DATE_TO);
+        assertThat(targets.get(0).baseDateTo()).isEqualTo(BASE_DATE_TO);
     }
 
     @Test
-    @DisplayName("자동 연동 대상 생성 - 실패 이력만 있으면 baseDateFrom은 null")
-    void buildAutoSyncTargets_withOnlyFailures_returnsNullBaseDateFrom() {
+    @DisplayName("자동 연동 대상 생성 - 실패 이력만 있으면 baseDateFrom은 baseDateTo")
+    void buildAutoSyncTargets_withOnlyFailures_returnsBaseDateToAsBaseDateFrom() {
         IndexInfo indexInfo = indexInfoRepository.save(createIndexInfo("KOSPI"));
         integrationTaskRepository.save(IntegrationTask.create(
             indexInfo, JobType.INDEX_DATA.name(), LocalDate.of(2026, 3, 10),
@@ -79,7 +80,9 @@ class IntegrationTaskServiceTest {
             List.of(indexInfo.getId()), BASE_DATE_TO
         );
 
-        assertThat(targets.get(0).baseDateFrom()).isNull();
+        assertThat(targets).hasSize(1);
+        assertThat(targets.get(0).baseDateFrom()).isEqualTo(BASE_DATE_TO);
+        assertThat(targets.get(0).baseDateTo()).isEqualTo(BASE_DATE_TO);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- closes #79 

## 작업 내용
- 자동 연동 대상 생성 시 연동 성공 이력이 없으면 `baseDateFrom`에 `baseDateTo`를 넣도록 정책 변경
- 변경된 정책에 맞춰 `IntegrationTaskService` 테스트 수정 및 케이스 추가
- 관련 정책 판단을 연동 대상 생성 단계에서 처리해, 연동 서비스가 연동 로직에 집중할 수 있도록 개선

## 변경 사항
- 마지막 성공 이력이 없는 경우 `baseDateFrom`을 `null`로 두지 않고 `baseDateTo`로 설정하도록 변경했습니다.
- 이에 따라 연동 이력이 없는 지수는 자동 연동 시 하루치 데이터만 요청하도록 동작이 명확해졌습니다.
- 테스트 코드의 기존 기대값을 새 정책에 맞게 수정하고, 무이력/실패 이력 케이스를 검증하도록 보완했습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트

## 스크린샷 / 참고 자료
- 없음
