### PR TITLE
feat: 연동 작업에 의한 지수정보 저장 및 수정 구현

### DIFF
--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -35,16 +35,13 @@ public class IndexInfoService {
     return indexInfoMapper.toDto(indexInfo);
   }
 
-  /* openApi 지수정보를 생성 및 저장
   public IndexInfoDto createIndexInfoByOpenAPI(IndexInfoCreateRequest request) {
-    validateDuplicateIndexInfo(request);
+    //validateDuplicateIndexInfo(request);//이미 새것만 저장이기 때문에 생략
     IndexInfo indexInfo = createEntity(request, SourceType.OPEN_API);
     indexInfoRepository.save(indexInfo);
-    indexInfoRepository.save(indexInfo);
-    autoIntegrationRepository.save(AutoIntegration.create(indexInfo));
-    return indexInfoMapper.toDto(indexInfo);
+    autoSyncConfigService.createAutoSyncConfig(indexInfo);
+    return indexInfoMapper.toDto(indexInfo); // 반환 값 필요없으면 삭제 가능
   }
-   */
 
   public IndexInfoDto updateIndexInfoByUser(UUID id, IndexInfoUpdateRequest request) {
     IndexInfo indexInfo = indexInfoRepository.findById(id)

--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -51,6 +51,12 @@ public class IndexInfoService {
     return indexInfoMapper.toDto(indexInfo);
   }
 
+  public IndexInfo updateIndexInfoByOpenAPI(IndexInfo indexInfo, IndexInfoUpdateRequest request) {
+    indexInfo.updateIndexInfo(request.employedItemsCount(), request.basePointInTime(),
+        request.baseIndex(), null);//즐겨찾기는 변경 없음
+    return indexInfo;
+  }
+
   public void deleteIndexInfo(UUID id) {
     if (!indexInfoRepository.existsById(id)) {
       throw new BusinessLogicException(ExceptionCode.INDEX_INFO_NOT_FOUND);

--- a/src/main/java/com/sprint/findex/service/IndexInfoService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoService.java
@@ -35,12 +35,12 @@ public class IndexInfoService {
     return indexInfoMapper.toDto(indexInfo);
   }
 
-  public IndexInfoDto createIndexInfoByOpenAPI(IndexInfoCreateRequest request) {
+  public IndexInfo createIndexInfoByOpenAPI(IndexInfoCreateRequest request) {
     //validateDuplicateIndexInfo(request);//이미 새것만 저장이기 때문에 생략
     IndexInfo indexInfo = createEntity(request, SourceType.OPEN_API);
     indexInfoRepository.save(indexInfo);
     autoSyncConfigService.createAutoSyncConfig(indexInfo);
-    return indexInfoMapper.toDto(indexInfo); // 반환 값 필요없으면 삭제 가능
+    return indexInfo;
   }
 
   public IndexInfoDto updateIndexInfoByUser(UUID id, IndexInfoUpdateRequest request) {


### PR DESCRIPTION
## 관련 이슈
- closes #87

## 작업 내용
- IndexInfoService에서 연동 서비스 호출을 위한 지수 정보 저장 로직을 구현(`createIndexInfoByOpenAPI`)
- IndexInfoService에서 연동 서비스 호출을 위한 지수 정보 수정 로직을 구현(`updateIndexInfoByOpenAPI`)

## 변경 사항
- 호출부에서 지수명과 지수 분류명으로 조회 후 저장 메서드를 호출하기 때문에 별도로 중복 체크를 하지 않습니다.
- 호출부에서 객체를 조회한 채로 수정 메서드를 호출하기 때문에, 별도 조회 없이 호출한 객체를 재사용합니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
