### PR TITLE
feat: open-api response 에 캐시 적용

### DIFF
--- a/src/main/java/com/sprint/findex/client/MarketIndexApiCacheService.java
+++ b/src/main/java/com/sprint/findex/client/MarketIndexApiCacheService.java
@@ -1,0 +1,85 @@
+package com.sprint.findex.client;
+
+import com.sprint.findex.dto.openapi.MarketIndexApiRequest;
+import com.sprint.findex.dto.openapi.MarketIndexApiResponse;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MarketIndexApiCacheService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter BASIC_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
+    private static final Duration TODAY_TTL = Duration.ofHours(1);
+    private static final Duration HISTORICAL_TTL = Duration.ofDays(7);
+
+    private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public MarketIndexApiResponse getOrLoad(
+            MarketIndexApiRequest request,
+            Supplier<MarketIndexApiResponse> loader
+    ) {
+        String cacheKey = buildCacheKey(request);
+        long now = System.currentTimeMillis();
+
+        CacheEntry cached = cache.get(cacheKey);
+        if (cached != null && !cached.isExpired(now)) {
+            return cached.response();
+        }
+
+        MarketIndexApiResponse response = loader.get();
+        long expiresAt = now + resolveTtl(request).toMillis();
+        cache.put(cacheKey, new CacheEntry(response, expiresAt));
+        return response;
+    }
+
+    private String buildCacheKey(MarketIndexApiRequest request) {
+        StringJoiner joiner = new StringJoiner("&");
+
+        for (Map.Entry<String, Object> entry : request.toQueryParams().entrySet()) {
+            joiner.add(entry.getKey() + "=" + entry.getValue());
+        }
+
+        return joiner.toString();
+    }
+
+    private Duration resolveTtl(MarketIndexApiRequest request) {
+        LocalDate latestRequestedDate = resolveLatestRequestedDate(request);
+        if (latestRequestedDate == null) {
+            return TODAY_TTL;
+        }
+
+        LocalDate today = LocalDate.now(KST);
+        return latestRequestedDate.isBefore(today) ? HISTORICAL_TTL : TODAY_TTL;
+    }
+
+    private LocalDate resolveLatestRequestedDate(MarketIndexApiRequest request) {
+        if (request.getBasDt() != null) {
+            return LocalDate.parse(request.getBasDt(), BASIC_DATE_FORMATTER);
+        }
+
+        if (request.getEndBasDt() != null) {
+            return LocalDate.parse(request.getEndBasDt(), BASIC_DATE_FORMATTER).minusDays(1);
+        }
+
+        if (request.getBeginBasDt() != null) {
+            return LocalDate.parse(request.getBeginBasDt(), BASIC_DATE_FORMATTER);
+        }
+
+        return null;
+    }
+
+    private record CacheEntry(MarketIndexApiResponse response, long expiresAt) {
+
+        private boolean isExpired(long now) {
+            return expiresAt <= now;
+        }
+    }
+}

--- a/src/main/java/com/sprint/findex/client/MarketIndexApiClient.java
+++ b/src/main/java/com/sprint/findex/client/MarketIndexApiClient.java
@@ -32,12 +32,15 @@ public class MarketIndexApiClient {
     private final MarketIndexApiProperties marketIndexApiProperties;
     private final ObjectMapper objectMapper;
     private final RestClient marketIndexRestClient;
+    private final MarketIndexApiCacheService marketIndexApiCacheService;
 
     public MarketIndexApiResponse getMarketIndex(MarketIndexApiRequest request) {
-        String rawBody = requestRawBody(request);
-        MarketIndexApiResponse response = parseResponse(rawBody);
-        validateApiResponse(response);
-        return response;
+        return marketIndexApiCacheService.getOrLoad(request, () -> {
+            String rawBody = requestRawBody(request);
+            MarketIndexApiResponse response = parseResponse(rawBody);
+            validateApiResponse(response);
+            return response;
+        });
     }
 
     private String requestRawBody(MarketIndexApiRequest request) {

--- a/src/test/java/com/sprint/findex/client/MarketIndexApiCacheServiceTest.java
+++ b/src/test/java/com/sprint/findex/client/MarketIndexApiCacheServiceTest.java
@@ -1,0 +1,85 @@
+package com.sprint.findex.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.findex.dto.openapi.MarketIndexApiRequest;
+import com.sprint.findex.dto.openapi.MarketIndexApiResponse;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MarketIndexApiCacheServiceTest {
+
+    private final MarketIndexApiCacheService cacheService = new MarketIndexApiCacheService();
+
+    @Test
+    @DisplayName("같은 과거 날짜 OpenAPI 요청은 캐시된 응답을 재사용")
+    void getOrLoad_reusesCachedResponseForSameHistoricalRequest() {
+        MarketIndexApiRequest request = MarketIndexApiRequest.builder()
+                .basDt("20260317")
+                .pageNo(1)
+                .numOfRows(100)
+                .build();
+        AtomicInteger loadCount = new AtomicInteger();
+
+        MarketIndexApiResponse first = cacheService.getOrLoad(request, () -> {
+            loadCount.incrementAndGet();
+            return response("1");
+        });
+
+        MarketIndexApiResponse second = cacheService.getOrLoad(request, () -> {
+            loadCount.incrementAndGet();
+            return response("2");
+        });
+
+        assertThat(loadCount.get()).isEqualTo(1);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("조건이 다른 OpenAPI 요청은 서로 다른 캐시 키를 사용")
+    void getOrLoad_usesDifferentCacheKeyForDifferentRequest() {
+        AtomicInteger loadCount = new AtomicInteger();
+
+        MarketIndexApiResponse first = cacheService.getOrLoad(
+                MarketIndexApiRequest.builder()
+                        .basDt("20260317")
+                        .pageNo(1)
+                        .numOfRows(100)
+                        .build(),
+                () -> {
+                    loadCount.incrementAndGet();
+                    return response("1");
+                }
+        );
+
+        MarketIndexApiResponse second = cacheService.getOrLoad(
+                MarketIndexApiRequest.builder()
+                        .basDt("20260318")
+                        .pageNo(1)
+                        .numOfRows(100)
+                        .build(),
+                () -> {
+                    loadCount.incrementAndGet();
+                    return response("2");
+                }
+        );
+
+        assertThat(loadCount.get()).isEqualTo(2);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    private MarketIndexApiResponse response(String totalCount) {
+        return new MarketIndexApiResponse(
+                new MarketIndexApiResponse.Response(
+                        new MarketIndexApiResponse.Header("00", "OK"),
+                        new MarketIndexApiResponse.Body(
+                                "100",
+                                "1",
+                                totalCount,
+                                new MarketIndexApiResponse.Items(null)
+                        )
+                )
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #91

## 작업 내용
- 병목 지점을 파악하여 금융위원회 지수시세정보 OpenAPI 조회에 캐시를 적용하였습니다.
- 동일한 요청 조건으로 반복 조회되는 OpenAPI 응답을 메모리 캐시에 저장하도록 구현하였습니다.
- 날짜 범위 조회는 요청 조건 단위 캐시 전략으로 유지하여 동일 조건 재요청 시 캐시를 재사용하도록 구성하였습니다.
- 공공기관 OpenAPI 특성상 과거 데이터는 변경되지 않고, 당일 데이터만 갱신될 수 있어 날짜 조건에 따라 TTL을 다르게 적용하였습니다.
    - `basDt` 또는 `endBasDt` 기준 실제 조회 대상의 마지막 날짜가 오늘 이전이면 과거 데이터로 판단하여 긴 TTL(7일)을 적용했습니다.
    - 오늘 날짜가 포함된 요청이나 날짜 판단이 어려운 요청은 당일 데이터 갱신 가능성을 고려해 짧은 TTL(1시간)을 적용했습니다.

## 변경 사항
- `MarketIndexApiCacheService`를 추가하여 OpenAPI 요청 파라미터 조합 기준 캐시 키를 생성하도록 구현했습니다.
- `MarketIndexApiClient`에서 OpenAPI 호출 전 캐시를 조회하고, 캐시 미스일 때만 실제 외부 API를 호출하도록 변경했습니다.
- 요청 대상 날짜가 과거인 경우와 오늘 포함 요청인 경우를 구분하여 TTL을 다르게 적용했습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 과거 요청과 오늘 포함 요청의 TTL 정책

## 스크린샷 / 참고 자료
<img width="825" height="97" alt="image" src="https://github.com/user-attachments/assets/11a59c63-db52-45f1-9acd-2a55da57e090" />

- 2020.1.1 ~ 2026.1.1 / KRX 반도체 데이터 연동 약 1000건 기준
<img width="1650" height="128" alt="image" src="https://github.com/user-attachments/assets/922f2240-1aab-4581-af38-abd00291f16a" />
<img width="992" height="124" alt="image" src="https://github.com/user-attachments/assets/8f7822d7-f2ed-450b-863d-f3676d12b1de" />

- 지수 정보 연동
<img width="821" height="59" alt="image" src="https://github.com/user-attachments/assets/2ecec7c2-ebe8-4f31-be73-060656a816bb" />
<img width="478" height="62" alt="image" src="https://github.com/user-attachments/assets/a479e563-a2ed-4374-b10b-fd4a4275fbc7" />

