### PR TITLE
refactor: 연동작업은 로깅 시, 별도의 임계 값 설정

### DIFF
--- a/src/main/java/com/sprint/findex/aop/TimeTraceAspect.java
+++ b/src/main/java/com/sprint/findex/aop/TimeTraceAspect.java
@@ -3,6 +3,7 @@ package com.sprint.findex.aop;
 import com.sprint.findex.exception.BusinessLogicException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -15,12 +16,20 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @Component
 public class TimeTraceAspect {
 
+  public static List<String> WHITE_LIST = List.of("syncIndexData", "syncIndexInfo");
+
   @Around(" execution(* com.sprint.findex.controller..*(..))")
   //서비스 레벨로 찍으려면 아래 문장을 추가해주세요
   //|| execution(* com.sprint.findex.service..*(..))
   public Object trace(ProceedingJoinPoint joinPoint) throws Throwable {
     long start = System.currentTimeMillis();
     boolean success = true;
+
+    String taskName = joinPoint.getSignature().toShortString();
+    String methodName = joinPoint.getSignature().getName();
+
+    //연동 작업은 별도의 임계값 설정
+    long threshold = WHITE_LIST.contains(methodName) ? 500L : 150L;
 
     try {
       return joinPoint.proceed();
@@ -32,7 +41,7 @@ public class TimeTraceAspect {
       if (params.length() > 100) {
         params = params.substring(0, 100) + "...";
       }
-      String taskName = joinPoint.getSignature().toShortString();
+
 
       if (//유효성검사 및 비즈니스 에러는 경고
           throwable instanceof MethodArgumentNotValidException ||
@@ -46,10 +55,9 @@ public class TimeTraceAspect {
     } finally {
       long end = System.currentTimeMillis();
       long time = end - start;
-      String taskName = joinPoint.getSignature().toShortString();
 
       if (success) { //성공 로그
-        if (time > 100) {
+        if (time > threshold) {
           log.warn("[SLOW] {} | {}ms", taskName, time);
         } else {
           log.info("[OK] {} | {}ms", taskName, time);


### PR DESCRIPTION
## 관련 이슈
- closes #100 

## 작업 내용
- 연동 작업(SyncIndexInfo, SyncIndexData)의 경우, 로그 OK 의 기준을 500ms으로 함.
- 기존 임계 값을 150으로 수정

## 변경 사항
- 기존 임계 값을 100에서 150으로 수정하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
