### PR TITLE
fix: 신규 지수 실패 이력 저장 처리

### DIFF
--- a/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexInfoRepository.java
@@ -23,4 +23,6 @@ public interface IndexInfoRepository extends JpaRepository<IndexInfo, UUID>,
 
     boolean existsByIndexClassificationAndIndexNameAndSourceType(String indexClassification,
             String indexName, SourceType sourceType);
+
+    Optional<IndexInfo> findByIndexClassificationAndIndexName(String indexClassification, String indexName);
 }

--- a/src/main/java/com/sprint/findex/service/IndexInfoSyncFailureService.java
+++ b/src/main/java/com/sprint/findex/service/IndexInfoSyncFailureService.java
@@ -1,11 +1,13 @@
 package com.sprint.findex.service;
 
 import com.sprint.findex.dto.sync.IndexInfoLookup;
+import com.sprint.findex.dto.sync.IndexInfoSyncSource;
 import com.sprint.findex.dto.sync.SyncJobDto;
 import com.sprint.findex.entity.IndexInfo;
 import com.sprint.findex.entity.IntegrationTask;
 import com.sprint.findex.enums.JobResult;
 import com.sprint.findex.enums.JobType;
+import com.sprint.findex.enums.SourceType;
 import com.sprint.findex.mapper.SyncJobMapper;
 import com.sprint.findex.repository.IndexInfoRepository;
 import com.sprint.findex.repository.IntegrationTaskRepository;
@@ -26,18 +28,15 @@ public class IndexInfoSyncFailureService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public SyncJobDto saveFailure(
             IndexInfoLookup lookup,
+            IndexInfoSyncSource source,
+            String standardName,
             String worker,
             Instant jobTime,
             String errorMessage
     ) {
-        // 신규 지수 정보라는 의미
-        // 정책 변경 혹은 개선 필요
-        if (lookup == null) {
-            return null;
-        }
-
         // IndexInfo 조회
-        IndexInfo indexInfo = indexInfoRepository.getReferenceById(lookup.id());
+        IndexInfo indexInfo = resolveFailureTarget(lookup, source, standardName);
+        
         // 연동 실패 이력 저장
         IntegrationTask failedTask = integrationTaskRepository.save(
                 IntegrationTask.create(
@@ -52,5 +51,32 @@ public class IndexInfoSyncFailureService {
         );
 
         return syncJobMapper.toDto(failedTask);
+    }
+
+    private IndexInfo resolveFailureTarget(
+            IndexInfoLookup lookup,
+            IndexInfoSyncSource source,
+            String standardName
+    ) {
+        if (lookup != null) {
+            return indexInfoRepository.getReferenceById(lookup.id());
+        }
+
+        // lookup은 연동 작업 시작 전에 만들기 때문에 최신 상태라는 보장이 없음
+        return indexInfoRepository.findByIndexClassificationAndIndexName(
+                        source.indexClassification(), standardName
+                )
+                // 신규 지수 정보일 경우 생성
+                .orElseGet(() -> indexInfoRepository.save(
+                        IndexInfo.create(
+                                standardName,
+                                source.indexClassification(),
+                                source.employedItemsCount(),
+                                source.basePointInTime(),
+                                source.baseIndex(),
+                                SourceType.OPEN_API,
+                                false
+                        )
+                ));
     }
 }

--- a/src/main/java/com/sprint/findex/service/IndexSyncService.java
+++ b/src/main/java/com/sprint/findex/service/IndexSyncService.java
@@ -90,6 +90,8 @@ public class IndexSyncService {
                     // 연동 실패 시 실패 이력 저장 시도
                     SyncJobDto failureJob = indexInfoSyncFailureService.saveFailure(
                             lookup,
+                            source,
+                            key.standardName,
                             worker,
                             jobTime,
                             syncException.getMessage()


### PR DESCRIPTION
## 관련 이슈
- closes #

## 작업 내용
- 신규 지수 연동 실패 시에도 실패 이력이 저장되도록 개선하였습니다.

## 변경 사항
- 지수 정보 조회 메서드가 추가되었습니다.
- `indexInfoSyncFailureService.saveFailure` 파라미터를 수정하였습니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
