### PR TITLE
fix: 배포 환경에서 지수데이터 export 에러 수정

### DIFF
--- a/src/main/java/com/sprint/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/findex/repository/IndexDataRepository.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,16 +15,6 @@ public interface IndexDataRepository extends JpaRepository<IndexData, UUID>,
         IndexDataCustomRepository {
 
     boolean existsByIndexInfo_IdAndBaseDate(UUID indexInfoId, LocalDate baseDate);
-
-    @Query("SELECT d FROM IndexData d " +
-            "WHERE (:indexInfoId IS NULL OR d.indexInfo.id = :indexInfoId) " +
-            "AND (:startDate IS NULL OR d.baseDate >= :startDate) " +
-            "AND (:endDate IS NULL OR d.baseDate <= :endDate)")
-    List<IndexData> findAllForExport(
-            @Param("indexInfoId") UUID indexInfoId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate,
-            Sort sort);
 
     long countByIndexInfoId(UUID indexInfoId);
 

--- a/src/main/java/com/sprint/findex/repository/dsl/IndexDataCustomRepository.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/IndexDataCustomRepository.java
@@ -2,9 +2,16 @@ package com.sprint.findex.repository.dsl;
 
 import com.sprint.findex.dto.indexdata.IndexDataDto;
 import com.sprint.findex.dto.indexdata.IndexDataQueryCondition;
+import com.sprint.findex.entity.IndexData;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
 
 public interface IndexDataCustomRepository {
 
     List<IndexDataDto> findAllWithIndexDataQueryCondition(IndexDataQueryCondition condition);
+
+    List<IndexData> findAllForExport(UUID indexInfoId, LocalDate startDate, LocalDate endDate,
+            Sort sort);
 }

--- a/src/main/java/com/sprint/findex/repository/dsl/impl/IndexDataCustomRepositoryImpl.java
+++ b/src/main/java/com/sprint/findex/repository/dsl/impl/IndexDataCustomRepositoryImpl.java
@@ -6,15 +6,18 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sprint.findex.dto.indexdata.IndexDataDto;
 import com.sprint.findex.dto.indexdata.IndexDataQueryCondition;
 import com.sprint.findex.dto.indexdata.IndexDataSortField;
+import com.sprint.findex.entity.IndexData;
 import com.sprint.findex.repository.dsl.IndexDataCustomRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,6 +25,20 @@ import org.springframework.stereotype.Repository;
 public class IndexDataCustomRepositoryImpl implements IndexDataCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<IndexData> findAllForExport(UUID indexInfoId, LocalDate startDate,
+            LocalDate endDate, Sort sort) {
+
+        return jpaQueryFactory
+                .selectFrom(indexData)
+                .where(
+                        indexInfoIdEq(indexInfoId),
+                        dateRange(startDate, endDate)
+                )
+                .orderBy(getExportOrderSpecifiers(sort))
+                .fetch();
+    }
 
     @Override
     public List<IndexDataDto> findAllWithIndexDataQueryCondition(
@@ -91,5 +108,24 @@ public class IndexDataCustomRepositoryImpl implements IndexDataCustomRepository 
     private OrderSpecifier<?> getIdOrderSpecifier(String sortDirection) {
         Order order = sortDirection.equals("desc") ? Order.DESC : Order.ASC;
         return new OrderSpecifier<>(order, indexData.id);
+    }
+
+    private OrderSpecifier<?>[] getExportOrderSpecifiers(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return new OrderSpecifier<?>[]{};
+        }
+
+        return sort.stream()
+                .map(order -> {
+                    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+                    PathBuilder<IndexData> pathBuilder = new PathBuilder<>(IndexData.class,
+                            "indexData");
+
+                    return new OrderSpecifier<>(
+                            direction,
+                            pathBuilder.getComparable(order.getProperty(), Comparable.class)
+                    );
+                })
+                .toArray(OrderSpecifier[]::new);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #109

## 작업 내용
- findAllExport 쿼리를 JPQL에서 QueryDSL로 변경

## 변경 사항
- IndexDataRepository에 있는 JPQL 쿼리로 작성된 findAllForExport 삭제
- IndexCustomRepository에 QueryDSL로 작성한 findAllForExport 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
