### PR TITLE
fix: 자동 연동 스케줄러 baseDateTo 어제로 변경

### DIFF
--- a/src/main/java/com/sprint/findex/scheduler/AutoSyncScheduler.java
+++ b/src/main/java/com/sprint/findex/scheduler/AutoSyncScheduler.java
@@ -36,8 +36,8 @@ public class AutoSyncScheduler {
                 return;
             }
 
-            LocalDate today = LocalDate.now(KST);
-            List<IndexDataSyncRequest> requests = integrationTaskService.buildAutoSyncTargets(indexInfoIds, today);
+            LocalDate yesterday = LocalDate.now(KST).minusDays(1);
+            List<IndexDataSyncRequest> requests = integrationTaskService.buildAutoSyncTargets(indexInfoIds, yesterday);
 
             log.info("자동 연동 대상: {}건", requests.size());
             indexSyncService.autoSyncIndexData(requests, WORKER_NAME);

--- a/src/test/java/com/sprint/findex/scheduler/AutoSyncSchedulerTest.java
+++ b/src/test/java/com/sprint/findex/scheduler/AutoSyncSchedulerTest.java
@@ -13,6 +13,7 @@ import com.sprint.findex.service.AutoSyncConfigService;
 import com.sprint.findex.service.IndexSyncService;
 import com.sprint.findex.service.IntegrationTaskService;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 @SpringBootTest(properties = "app.scheduler.fixed-delay-ms=1000")
 @ActiveProfiles("test")
 class AutoSyncSchedulerTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @MockitoSpyBean
     private AutoSyncScheduler autoSyncScheduler;
@@ -60,18 +63,19 @@ class AutoSyncSchedulerTest {
     }
 
     @Test
-    @DisplayName("활성화된 대상이 있으면 오늘 기준으로 연동 서비스를 호출한다")
-    void syncIndexData_withEnabledTargets_callsSyncServiceWithToday() {
+    @DisplayName("활성화된 대상이 있으면 KST 기준 어제로 연동 서비스를 호출한다")
+    void syncIndexData_withEnabledTargets_callsSyncServiceWithYesterday() {
         UUID indexInfoId = UUID.randomUUID();
         IndexDataSyncRequest request = new IndexDataSyncRequest(List.of(indexInfoId), null, null);
+        LocalDate yesterday = LocalDate.now(KST).minusDays(1);
 
         when(autoSyncConfigService.findEnabledIndexInfoIds()).thenReturn(List.of(indexInfoId));
-        when(integrationTaskService.buildAutoSyncTargets(eq(List.of(indexInfoId)), any(LocalDate.class)))
+        when(integrationTaskService.buildAutoSyncTargets(eq(List.of(indexInfoId)), eq(yesterday)))
             .thenReturn(List.of(request));
 
         autoSyncScheduler.syncIndexData();
 
-        verify(integrationTaskService).buildAutoSyncTargets(eq(List.of(indexInfoId)), any(LocalDate.class));
+        verify(integrationTaskService).buildAutoSyncTargets(eq(List.of(indexInfoId)), eq(yesterday));
         verify(indexSyncService).autoSyncIndexData(eq(List.of(request)), any());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #

## 작업 내용
- Open-api 의 지수데이터가 당일의 전날 자료가 업데이트 되는걸로 확인
- 어제 기준 요청으로 변경

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
