### PR TITLE
fix: 지수 정보 삭제 메서드의 반환 엔티티 타입 선언을 와일드 카드로 변경

### DIFF
--- a/src/main/java/com/sprint/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/sprint/findex/controller/IndexInfoController.java
@@ -46,7 +46,7 @@ public class IndexInfoController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<IndexInfoDto> deleteIndexInfo(
+    public ResponseEntity<?> deleteIndexInfo(
             @PathVariable UUID id) {
         indexInfoService.deleteIndexInfo(id);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## 관련 이슈
- closes #

## 작업 내용
- 지수 정보 삭제 메서드의 반환 엔티티 타입 선언을 와일드 카드로 변경
- 기존 IndexInfoDto로 잘못 선언된 타입을 수정

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
