### PR TITLE
chore: swagger 서버 주소 변경

### DIFF
--- a/src/main/java/com/sprint/findex/config/OpenApiConfig.java
+++ b/src/main/java/com/sprint/findex/config/OpenApiConfig.java
@@ -3,11 +3,15 @@ package com.sprint.findex.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+
+    @Value("${findex.server-url}")
+    private String serverUrl;
 
     @Bean
     public OpenAPI openAPI() {
@@ -17,8 +21,6 @@ public class OpenApiConfig {
                         .description("가볍고 빠른 외부 API 연동 금융 분석 도구 API 문서")
                 )
                 .addServersItem(new Server()
-                        .url("http://localhost:8080")
-                        .description("로컬 서버")
-                );
+                    .url(serverUrl).description("현재 환경 서버"));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,8 @@ spring:
 server:
   port: ${PORT:8080}
 
+findex:
+  server-url: ${SERVER_URL:http://localhost:8080}
 app:
   scheduler:
     enabled: true


### PR DESCRIPTION
## 관련 이슈
- closes #125

## 작업 내용
- swagger 서버 주소가 현재 서버로 표시되도록 변경
- `OpeanApiConfig.java`파일에서 시스템 환경변수를 사용하도록 했습니다.
- `application.yaml`에 `SERVER_URL` 추가

## 변경 사항
- swagger 서버 주소가 현재 서버로 표시되도록 변경하였습니다.
  - 별도의 환경 변수가 없는 경우, localhost로 사용됩니다.

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
<img width="1418" height="716" alt="image" src="https://github.com/user-attachments/assets/5e2e5fb3-e2ac-479a-b25a-f0c1d89599be" />
